### PR TITLE
Fixes not being able to load configuration correctly in L4

### DIFF
--- a/src/VTalbot/Markdown/MarkdownServiceProvider.php
+++ b/src/VTalbot/Markdown/MarkdownServiceProvider.php
@@ -18,7 +18,7 @@ class MarkdownServiceProvider extends ServiceProvider {
      */
     public function register()
     {
-        $this->app['config']->package('vtalbot/markdown', 'vtalbot/markdown', 'vtalbot/markdown');
+        $this->app['config']->package('vtalbot/markdown', __DIR__.'/../../../config');
 
         $this->registerRoutes();
 


### PR DESCRIPTION
When installing the package and registering it, errors occur in the registerRoutes function as the Config options retrieved are null (due to the config being registered incorrectly).

A similar error occurs in registerMarkdownFinder() as well. This fixes both
