### PR TITLE
Fix Null Return on Environment.php

### DIFF
--- a/src/VTalbot/Markdown/Environment.php
+++ b/src/VTalbot/Markdown/Environment.php
@@ -164,7 +164,7 @@ class Environment {
 
         return array_first($extensions, function($key, $value) use ($path)
             {
-                return ends_with($path, $value);
+                return ends_with($path, $key);
             });
     }
 


### PR DESCRIPTION
Used your package with Laravel but couldn't render a md file cause Laravel threw Undefined Index errors because ends_with($path, $value) returned null all the time. Found out it has to be $key instead of $value